### PR TITLE
Add types for Overrides

### DIFF
--- a/packages/jsx-ui/src/Divider.tsx
+++ b/packages/jsx-ui/src/Divider.tsx
@@ -12,10 +12,7 @@ export type DividerProps = {
 export const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
   (props, ref) => {
     const parentAxis = React.useContext(StackContext)
-    const { color = '#000', size = 1 } = useOverrideProps<DividerProps>(
-      Divider,
-      props
-    )
+    const { color = '#000', size = 1 } = useOverrideProps(Divider, props)
     const isHorizontal = parentAxis === 'horizontal'
     return (
       <div

--- a/packages/jsx-ui/src/Image.tsx
+++ b/packages/jsx-ui/src/Image.tsx
@@ -21,7 +21,7 @@ export const Image = React.forwardRef<HTMLSpanElement, ImageProps>(
       style,
       children,
       ...restProps
-    } = useOverrideProps<ImageProps>(Image, props)
+    } = useOverrideProps(Image, props)
     return (
       <img
         ref={ref}

--- a/packages/jsx-ui/src/Overrides.tsx
+++ b/packages/jsx-ui/src/Overrides.tsx
@@ -4,14 +4,14 @@ import { getInstance } from './utils'
 
 const OverridesContext = React.createContext([])
 
-export function useOverrideProps<Props>(instance, props) {
-  const OverridesStack = React.useContext(OverridesContext)
+export function useOverrideProps<Props>(component, props) {
+  const overridesStack = React.useContext(OverridesContext)
   let modifiedProps = {} as Props
-  OverridesStack.forEach(Overrides => {
-    Overrides.forEach(override => {
+  overridesStack.forEach(overrides => {
+    overrides.forEach(override => {
       const components = override.slice(0, -1).map(getInstance)
       const overrideProps = override.slice(-1)[0]
-      if (components.includes(getInstance(instance))) {
+      if (components.includes(getInstance(component))) {
         modifiedProps = {
           ...modifiedProps,
           ...overrideProps,
@@ -23,6 +23,13 @@ export function useOverrideProps<Props>(instance, props) {
     ...modifiedProps,
     ...props,
   }
+}
+
+export function override<C extends React.ElementType>(
+  component: C,
+  props: React.ComponentProps<C>
+): [C, React.ComponentProps<C>] {
+  return [component, props]
 }
 
 export function Overrides({ value, children }) {

--- a/packages/jsx-ui/src/Overrides.tsx
+++ b/packages/jsx-ui/src/Overrides.tsx
@@ -4,9 +4,9 @@ import { getInstance } from './utils'
 
 const OverridesContext = React.createContext([])
 
-export function useOverrideProps<Props>(component, props) {
+export function useOverrideProps(component, props) {
   const overridesStack = React.useContext(OverridesContext)
-  let modifiedProps = {} as Props
+  let modifiedProps = {} as React.ComponentProps<typeof component>
   overridesStack.forEach(overrides => {
     overrides.forEach(override => {
       const components = override.slice(0, -1).map(getInstance)

--- a/packages/jsx-ui/src/Overrides.tsx
+++ b/packages/jsx-ui/src/Overrides.tsx
@@ -4,7 +4,7 @@ import { getInstance } from './utils'
 
 const OverridesContext = React.createContext([])
 
-export function useOverrideProps(component, props) {
+export function useOverrideProps(component: React.ElementType, props: object) {
   const overridesStack = React.useContext(OverridesContext)
   let modifiedProps = {} as React.ComponentProps<typeof component>
   overridesStack.forEach(overrides => {
@@ -32,7 +32,12 @@ export function override<C extends React.ElementType>(
   return [component, props]
 }
 
-export function Overrides({ value, children }) {
+export type OverridesProps = {
+  value: [React.ElementType, object][]
+  children: React.ReactNode
+}
+
+export function Overrides({ value, children }: OverridesProps) {
   const parentOverrides = React.useContext(OverridesContext)
   return (
     <OverridesContext.Provider value={[...parentOverrides, value]}>

--- a/packages/jsx-ui/src/Spacer.tsx
+++ b/packages/jsx-ui/src/Spacer.tsx
@@ -14,7 +14,7 @@ type SpacerProps = {
 }
 
 export function Spacer(props: SpacerProps) {
-  const modifiedProps = useOverrideProps<SpacerProps>(Spacer, props)
+  const modifiedProps = useOverrideProps(Spacer, props)
   const { children, size = '1fr', visible = true } = useVariantProps<
     SpacerProps
   >(modifiedProps)

--- a/packages/jsx-ui/src/Stack.tsx
+++ b/packages/jsx-ui/src/Stack.tsx
@@ -5,6 +5,7 @@ import { Divider } from './Divider'
 import { useOverrideProps } from './Overrides'
 import { Spacer } from './Spacer'
 import { Text } from './Text'
+import { useTokens } from './Tokens'
 import { useVariantProps } from './Variants'
 import { SharedProps } from './index'
 import { useLayoutStyles } from './use-layout-styles'
@@ -122,7 +123,7 @@ export function getStackChildStyles({ width, height }) {
 export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
   (props: StackProps, ref) => {
     const mainAxis = React.useContext(StackContext)
-    const overrideProps = useOverrideProps<StackProps>(Stack, props)
+    const overrideProps = useOverrideProps(Stack, props)
     const {
       as: Component = 'div',
       axis = 'vertical',
@@ -158,6 +159,7 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
       style: _style,
       ...restProps
     } = useVariantProps<StackProps>(overrideProps)
+    const { colors } = useTokens()
     const flattenedChildren = React.Children.toArray(children)
       .flatMap((child: any) =>
         child && child.type === React.Fragment ? child.props.children : child
@@ -183,7 +185,10 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
         parseValue(radiusBottomRight ?? radius),
         parseValue(radiusBottomLeft ?? radius),
       ].join(' '),
-      background,
+      background:
+        typeof background === 'string'
+          ? colors[background] || background
+          : undefined,
       transform: getTransformValue({
         scale,
         scaleX,

--- a/packages/jsx-ui/src/Text.tsx
+++ b/packages/jsx-ui/src/Text.tsx
@@ -11,10 +11,12 @@ import { parseValue } from './utils'
 
 export type TextProps = {
   as?: any
+  alignment?: 'left' | 'center' | 'right'
   family?: string
   size?: string | number
   lineSpacing?: number
   weight?: string | number
+  backgroundColor?: string
   color?: string
   offsetX?: string | number
   offsetY?: string | number
@@ -31,15 +33,17 @@ export type TextProps = {
 export const Text = React.forwardRef<HTMLSpanElement, TextProps>(
   (props, ref) => {
     const mainAxis = React.useContext(StackContext)
-    const overrideProps = useOverrideProps<TextProps>(Text, props)
+    const overrideProps = useOverrideProps(Text, props)
     const {
       as: Component = 'span',
+      alignment,
       column,
       row,
       family,
       size,
-      lineSpacing = 12,
+      lineSpacing = 0,
       weight,
+      backgroundColor,
       color,
       offsetX,
       offsetY,
@@ -89,9 +93,11 @@ export const Text = React.forwardRef<HTMLSpanElement, TextProps>(
           display: 'inline-block',
           gridColumn: column,
           gridRow: row,
+          textAlign: alignment,
           fontFamily: fontFamilies[family] || family,
           fontSize: fontSizes[size] || size,
           fontWeight: fontWeights[weight] || weight,
+          backgroundColor: colors[backgroundColor] || backgroundColor,
           color: colors[color] || color,
           transform: `translate(${parseValue(translateX)}, ${parseValue(
             translateY

--- a/packages/site/src/components/Layout.js
+++ b/packages/site/src/components/Layout.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { DevTools, Overrides, Text, Tokens, Stack } from 'jsx-ui'
+import { DevTools, Overrides, override, Text, Tokens, Stack } from 'jsx-ui'
 
 import './layout.css'
 
@@ -75,15 +75,12 @@ const playstationTokens = {
 }
 
 const overrides = [
-  [
-    Text,
-    {
-      family: 'body',
-      size: 'medium',
-      weight: 'light',
-      color: 'foreground',
-    },
-  ],
+  override(Text, {
+    family: 'body',
+    size: 'medium',
+    weight: 'light',
+    color: 'foreground',
+  }),
 ]
 
 function Layout({ children, location }) {


### PR DESCRIPTION
Adds an `override` function to properly type overridden components:

```jsx
<Overrides
  value={[
    override(Text, {
      family: 'body',
      size: 'medium',
      weight: 'light',
      color: 'foreground',
    })
  ]}
>
  <Text>Hello Text</Text>
</Overrides>
```