### PR TITLE
add component source

### DIFF
--- a/packages/react/src/Stack.tsx
+++ b/packages/react/src/Stack.tsx
@@ -72,7 +72,7 @@ function joinChildren(children, separator: any = ', ') {
   }, [])
 }
 
- function parseSpaceValue(value) {
+function parseSpaceValue(value) {
   return typeof value === 'string' || typeof value === 'number' ? (
     <Spacer size={value} />
   ) : (
@@ -173,7 +173,7 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
         child && child.type === React.Fragment ? child.props.children : child
       )
       .filter(
-        child =>
+        (child) =>
           // @ts-ignore
           React.isValidElement(child) && child.props.visible !== false
       )
@@ -215,7 +215,7 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
     const childrenToRender =
       spaceCrossStart ?? spaceCrossEnd ?? spaceCross ?? space
         ? flattenedChildren.map((child: any, index) => {
-            const type = child.props.originalType || child.type
+            const type = child.props.__originalType || child.type
             return isSameInstance(type, [Spacer, Divider]) ? (
               child
             ) : (

--- a/packages/react/src/jsx.tsx
+++ b/packages/react/src/jsx.tsx
@@ -4,14 +4,19 @@ import { useOverrideProps } from './Overrides'
 import { useVariantProps } from './Variants'
 
 type CreateElementProps = {
-  originalType: React.ElementType
+  __originalType: React.ElementType
+  __jsxuiSource: {
+    fileName: string
+    lineNumber: number
+    columnNumber: number
+  }
 }
 
 export const CreateElement = React.forwardRef(
-  ({ originalType, ...props }: CreateElementProps, ref) => {
-    const overrideProps = useOverrideProps(originalType, props)
+  ({ __originalType, __jsxuiSource, ...props }: CreateElementProps, ref) => {
+    const overrideProps = useOverrideProps(__originalType, props)
     const variantProps = useVariantProps(overrideProps)
-    return React.createElement(originalType, { ref, ...variantProps })
+    return React.createElement(__originalType, { ref, ...variantProps })
   }
 )
 
@@ -20,7 +25,7 @@ CreateElement.displayName = 'JSXUICreateElement'
 export function jsx(type, props, ...children) {
   return React.createElement(
     CreateElement,
-    { originalType: type, ...props },
+    { __originalType: type, ...props },
     ...children
   )
 }

--- a/packages/site/.babelrc
+++ b/packages/site/.babelrc
@@ -1,4 +1,20 @@
 {
-  "plugins": ["babel-plugin-jsxui"],
+  "plugins": [
+    "babel-plugin-jsxui",
+    [
+      "babel-plugin-transform-react-jsx",
+      {
+        "pragma": "jsx"
+      }
+    ],
+    [
+      "@emotion/babel-plugin-jsx-pragmatic",
+      {
+        "module": "@jsxui/react",
+        "import": "jsx",
+        "export": "jsx"
+      }
+    ]
+  ],
   "presets": ["babel-preset-gatsby"]
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -11,9 +11,11 @@
     "deploy": "gatsby build --prefix-paths && gh-pages -d public"
   },
   "dependencies": {
+    "@emotion/babel-plugin-jsx-pragmatic": "^0.1.5",
     "@jsxui/react": "*",
     "@react-aria/interactions": "^3.3.1",
     "babel-plugin-jsxui": "*",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-gatsby": "^0.6.0",
     "case-anything": "^1.1.2",
     "dotenv": "^8.2.0",

--- a/packages/site/src/assets.js
+++ b/packages/site/src/assets.js
@@ -1,5 +1,4 @@
-/** @jsx jsx */
-import { Graphic, jsx } from '@jsxui/react'
+import { Graphic } from '@jsxui/react'
 export const Logo = (props) => (
   <Graphic
     height="80"

--- a/packages/site/src/pages/index.js
+++ b/packages/site/src/pages/index.js
@@ -1,6 +1,5 @@
-/** @jsx jsx */
 import React from 'react'
-import { jsx, Text, Tokens, Spacer, Stack, Variants } from '@jsxui/react'
+import { Text, Tokens, Spacer, Stack, Variants } from '@jsxui/react'
 
 import { Github, Logo, Wave } from '../assets'
 


### PR DESCRIPTION
Adds component source using a modified version of [babel-plugin-transform-react-jsx-source](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-react-jsx-source/) as well as enables the `jsx` pragma for the Gatsby site.