### PR TITLE
feat(Variants): add support for hooks

### DIFF
--- a/packages/react/src/Variants.tsx
+++ b/packages/react/src/Variants.tsx
@@ -9,16 +9,19 @@ export function useVariantProps<Props>({
   const contextVariants = React.useContext(VariantsContext)
   let mergedProps = { ...props }
   if (variants) {
-    const activeVariants = Object.entries(contextVariants)
-      .filter(([, active]) => active)
-      .map(([prop]) => prop)
-    activeVariants.forEach((activeVariant) => {
-      const variantProps = variants[activeVariant]
-      mergedProps = {
-        ...mergedProps,
-        ...(typeof variantProps === 'function'
+    Object.entries(contextVariants).forEach(([variant, active]) => {
+      const variantProps = variants[variant]
+      // we intentionally call each function no matter what since variants can
+      // contain hooks and need to run in the same order on every render
+      const nextProps =
+        typeof variantProps === 'function'
           ? variantProps(mergedProps)
-          : variantProps),
+          : variantProps
+      if (active) {
+        mergedProps = {
+          ...mergedProps,
+          ...nextProps,
+        }
       }
     })
   }


### PR DESCRIPTION
This adds support for using hooks in variants.

```jsx
function useHover() {
  const [hover, setHover] = React.useState(false)
  return {
    onMouseOver: () => {
      setHover(true)
    },
    onMouseOut: () => {
      setHover(false)
    },
    style: {
      boxShadow: hover && `0px 0px 0px 2px blue`,
    },
  }
}

function Button(props) {
  const variantProps = useVariantProps(props)
  return <button {...variantProps} />
}

function App() {
  return (
    <Variants value={{ hover: true }}>
      <Button variants={{ hover: useHover }} />
    </Variants>
  )
}
```