### PR TITLE
feat: add better as prop types

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "capsize": "^1.1.0",
     "lodash.debounce": "^4.0.8",
+    "react-polymorphic-box": "^3.0.2",
     "zustand": "^3.2.0"
   }
 }

--- a/packages/react/src/Stack.tsx
+++ b/packages/react/src/Stack.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { StackContext } from './Contexts'
 import { Divider } from './Divider'
-import { SharedProps } from './index'
+import { DefaultProps } from './index'
 import { jsx } from './jsx'
 import { Spacer } from './Spacer'
 import { Text } from './Text'
@@ -10,7 +10,7 @@ import { useTokens } from './Tokens'
 import { useLayoutStyles } from './use-layout-styles'
 import { parseValue, isSameInstance } from './utils'
 
-export type StackProps = {
+export type StackOwnProps = {
   as?: any
   axis?: 'horizontal' | 'vertical'
   size?: number | string
@@ -43,7 +43,14 @@ export type StackProps = {
   background?: string | React.ReactNode
   style?: React.CSSProperties
   children?: React.ReactNode
-} & SharedProps
+}
+
+export type StackProps<E extends React.ElementType> = DefaultProps<
+  E,
+  StackOwnProps
+>
+
+const defaultElement = 'div'
 
 function joinChildren(children, separator: any = ', ') {
   const childrenArray = React.Children.toArray(children)
@@ -120,8 +127,11 @@ export function getStackChildStyles({ width, height }) {
   return style
 }
 
-export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
-  (props: StackProps, ref) => {
+export const Stack = React.forwardRef(
+  <E extends React.ElementType = typeof defaultElement>(
+    props: StackProps<E>,
+    ref
+  ) => {
     const mainAxis = React.useContext(StackContext)
     const {
       as: Component = 'div',
@@ -163,7 +173,7 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
         child && child.type === React.Fragment ? child.props.children : child
       )
       .filter(
-        (child) =>
+        child =>
           // @ts-ignore
           React.isValidElement(child) && child.props.visible !== false
       )
@@ -296,6 +306,9 @@ export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
       </StackContext.Provider>
     )
   }
-)
+) as <E extends React.ElementType = typeof defaultElement>(
+  props: StackProps<E>
+) => React.ReactElement
 
+// @ts-ignore
 Stack.displayName = 'Stack'

--- a/packages/react/src/Text.tsx
+++ b/packages/react/src/Text.tsx
@@ -3,12 +3,11 @@ import capsize from 'capsize'
 
 import { StackContext } from './Contexts'
 import { useTokens } from './Tokens'
-import { SharedProps } from './index'
+import { DefaultProps } from './index'
 import { useLayoutStyles } from './use-layout-styles'
 import { parseValue } from './utils'
 
-export type TextProps = {
-  as?: any
+export type TextOwnProps = {
   alignment?: 'left' | 'center' | 'right'
   family?: string
   size?: string | number
@@ -26,10 +25,20 @@ export type TextProps = {
   spaceBefore?: number | string
   style?: React.CSSProperties
   children?: React.ReactNode
-} & SharedProps
+}
 
-export const Text = React.forwardRef<HTMLSpanElement, TextProps>(
-  (props, ref) => {
+export type TextProps<E extends React.ElementType> = DefaultProps<
+  E,
+  TextOwnProps
+>
+
+const defaultElement = 'span'
+
+export const Text = React.forwardRef(
+  <E extends React.ElementType = typeof defaultElement>(
+    props: TextProps<E>,
+    ref
+  ) => {
     const mainAxis = React.useContext(StackContext)
     const {
       as: Component = 'span',
@@ -126,6 +135,9 @@ export const Text = React.forwardRef<HTMLSpanElement, TextProps>(
       </Component>
     )
   }
-)
+) as <E extends React.ElementType = typeof defaultElement>(
+  props: TextProps<E>
+) => React.ReactElement
 
+// @ts-ignore
 Text.displayName = 'Text'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,10 +1,3 @@
-export type SharedProps = {
-  column?: string
-  row?: string
-  variants?: any
-  visible?: boolean | string
-}
-
 export * from './Circle'
 export * from './DevTools'
 export * from './Divider'
@@ -19,3 +12,4 @@ export * from './Variants'
 
 export * from './jsx'
 export * from './use-geometry'
+export * from './types'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { PolymorphicComponentProps } from 'react-polymorphic-box'
+
+export type DefaultProps<
+  C extends React.ElementType,
+  Props = {}
+> = PolymorphicComponentProps<C, Props> & {
+  column?: string
+  row?: string
+  variants?: any
+  visible?: boolean | string
+}
+
+export type SharedProps = {
+  column?: string
+  row?: string
+  variants?: any
+  visible?: boolean | string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11238,6 +11238,11 @@ react-maps-google@^0.4.10:
     prop-types "^15.6.1"
     react-load-script "0.0.6"
 
+react-polymorphic-box@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-polymorphic-box/-/react-polymorphic-box-3.0.2.tgz#f7830deac08b0ae55226a85a2cc2bfa0af53e8f1"
+  integrity sha512-6nTfLUgYPuniGaosD2uDMmS/ZHh4xu2BtscNYZK6HMaVyDgdk4qo2grsEBreOR5CS9Lz4wS835DBKPZ53dFPXg==
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"


### PR DESCRIPTION
Adds `react-polymorphic-box` and sets it up for `Stack` and `Text`. Will move over the remaining components in a future PR.