### PR TITLE
feat(Stack): update space props to use x/y

### DIFF
--- a/packages/react/src/Stack.tsx
+++ b/packages/react/src/Stack.tsx
@@ -31,23 +31,23 @@ export type StackOwnProps = {
   /** Shortcut to set all space props. */
   space?: SpaceValue
 
-  /** Defines space along the main axis. */
-  spaceMain?: SpaceValue
+  /** Defines space along the x-axis. */
+  spaceX?: SpaceValue
 
-  /** Defines space along the main start axis. */
-  spaceMainStart?: SpaceValue
+  /** Defines space along the x-start-axis. */
+  spaceXStart?: SpaceValue
 
-  /** Defines space along the main end axis. */
-  spaceMainEnd?: SpaceValue
+  /** Defines space along the x-end-axis. */
+  spaceXEnd?: SpaceValue
 
-  /** Defines space along the cross axis. */
-  spaceCross?: SpaceValue
+  /** Defines space along the y-axis. */
+  spaceY?: SpaceValue
 
-  /** Defines space along the cross start axis. */
-  spaceCrossStart?: SpaceValue
+  /** Defines space along the y-start-axis. */
+  spaceYStart?: SpaceValue
 
-  /** Defines space along the cross end axis. */
-  spaceCrossEnd?: SpaceValue
+  /** Defines space along the y-end-axis. */
+  spaceYEnd?: SpaceValue
 
   /** Defines space between child views. */
   spaceBetween?: SpaceValue
@@ -203,12 +203,12 @@ export const Stack = React.forwardRef(
       width,
       height,
       space,
-      spaceMain,
-      spaceMainStart,
-      spaceMainEnd,
-      spaceCross,
-      spaceCrossStart,
-      spaceCrossEnd,
+      spaceX,
+      spaceXStart,
+      spaceXEnd,
+      spaceY,
+      spaceYStart,
+      spaceYEnd,
       spaceBetween,
       spaceBefore,
       spaceAfter,
@@ -243,6 +243,19 @@ export const Stack = React.forwardRef(
     const layoutStyles = useLayoutStyles(
       (mainAxis === 'horizontal' ? width : height) ?? size
     )
+    const isHorizontal = axis === 'horizontal'
+    const spaceMainStart = isHorizontal
+      ? spaceXStart ?? spaceX ?? space
+      : spaceYStart ?? spaceY ?? space
+    const spaceMainEnd = isHorizontal
+      ? spaceXEnd ?? spaceX ?? space
+      : spaceYEnd ?? spaceY ?? space
+    const spaceCrossStart = isHorizontal
+      ? spaceYStart ?? spaceY ?? space
+      : spaceXStart ?? spaceX ?? space
+    const spaceCrossEnd = isHorizontal
+      ? spaceYEnd ?? spaceY ?? space
+      : spaceXEnd ?? spaceX ?? space
     const style = {
       display: 'flex',
       flexDirection: axis === 'horizontal' ? 'row' : 'column',
@@ -275,7 +288,7 @@ export const Stack = React.forwardRef(
       ..._style,
     }
     const childrenToRender =
-      spaceCrossStart ?? spaceCrossEnd ?? spaceCross ?? space
+      spaceCrossStart ?? spaceCrossEnd
         ? flattenedChildren.map((child: any, index) => {
             return isSameInstance(child, [Spacer, Divider]) ? (
               child
@@ -305,12 +318,7 @@ export const Stack = React.forwardRef(
                     ...child.props.style,
                   }}
                 >
-                  {parseSpaceValue(
-                    child.props.spaceBefore ??
-                      spaceCrossStart ??
-                      spaceCross ??
-                      space
-                  )}
+                  {parseSpaceValue(child.props.spaceBefore ?? spaceCrossStart)}
                   {React.cloneElement(child, {
                     style: getStackChildStyles({
                       width:
@@ -325,12 +333,7 @@ export const Stack = React.forwardRef(
                           : 'auto',
                     }),
                   })}
-                  {parseSpaceValue(
-                    child.props.spaceAfter ??
-                      spaceCrossEnd ??
-                      spaceCross ??
-                      space
-                  )}
+                  {parseSpaceValue(child.props.spaceAfter ?? spaceCrossEnd)}
                 </div>
               </StackContext.Provider>
             )
@@ -359,11 +362,11 @@ export const Stack = React.forwardRef(
               {background}
             </div>
           )}
-          {parseSpaceValue(spaceMainStart ?? spaceMain ?? space)}
+          {parseSpaceValue(spaceMainStart)}
           {spaceBetween
             ? joinChildren(childrenToRender, parseSpaceValue(spaceBetween))
             : childrenToRender}
-          {parseSpaceValue(spaceMainEnd ?? spaceMain ?? space)}
+          {parseSpaceValue(spaceMainEnd)}
         </Component>
       </StackContext.Provider>
     )

--- a/packages/site/src/pages/index.js
+++ b/packages/site/src/pages/index.js
@@ -27,17 +27,17 @@ export default function Index() {
       }}
     >
       <Stack height="minmax(100vh, auto)">
-        <Stack axis="horizontal" spaceMain="minmax(16px, 1fr)">
+        <Stack axis="horizontal" spaceX="minmax(16px, 1fr)">
           <Stack
             width="minmax(auto, 960px)"
-            spaceMainStart="16px"
-            spaceMainEnd="minmax(16px, 1fr)"
-            spaceCross="1fr"
+            spaceX="1fr"
+            spaceYStart="16px"
+            spaceYEnd="minmax(16px, 1fr)"
           >
             <Stack
               axis="horizontal"
               width="1fr"
-              spaceCross="1fr"
+              spaceY="1fr"
               spaceBefore={0}
               spaceAfter={0}
             >


### PR DESCRIPTION
Currently space props are based off of the main/cross axis inspired by Flexbox. This comes with some nuances that don't play well in a responsive environment.

Take for example, a typical layout that is vertical on small screens, but horizontal on larger screens. Since space is based on the main axis in this example, it will swap when the axis changes:
```jsx
<Stack
  spaceMain="16px"
  variants={{ 'breakpoints.medium': { axis: 'horizontal' } }}
>
  <Rectangle />
  <Rectangle />
  <Rectangle />
</Stack>
```

With the proposed changes we use `x` and `y` terminology to set horizontal and vertical spacings. Now horizontal space will be maintained no matter if the axis is changed:
```jsx
<Stack
  spaceX="16px"
  variants={{ 'breakpoints.medium': { axis: 'horizontal' } }}
>
  <Rectangle />
  <Rectangle />
  <Rectangle />
</Stack>
```

I may come back to main/cross language when looking into internationalization, but for now x/y seems more simple and less nuanced.