### PR TITLE
feat: add useChildProps hook

### DIFF
--- a/packages/react/src/Overrides.tsx
+++ b/packages/react/src/Overrides.tsx
@@ -4,26 +4,30 @@ import { isSameInstance } from './utils'
 
 export const OverridesContext = React.createContext([])
 
-export function useOverrideProps<C extends React.ElementType>(
-  component: C,
-  props: React.ComponentProps<C>
-): React.ComponentProps<C> {
-  const overridesStack = React.useContext(OverridesContext)
-  let modifiedProps = {} as React.ComponentProps<typeof component>
-  overridesStack.forEach(overrides => {
+export function getOverrideProps(overridesContext, component, props) {
+  let overrideProps = {} as React.ComponentProps<typeof component>
+  overridesContext.forEach((overrides) => {
     overrides.forEach(([instance, props]) => {
       if (isSameInstance(instance, component)) {
-        modifiedProps = {
-          ...modifiedProps,
-          ...(typeof props === 'function' ? props(modifiedProps) : props),
+        overrideProps = {
+          ...overrideProps,
+          ...(typeof props === 'function' ? props(overrideProps) : props),
         }
       }
     })
   })
   return {
-    ...modifiedProps,
+    ...overrideProps,
     ...props,
   }
+}
+
+export function useOverrideProps<C extends React.ElementType>(
+  component: C,
+  props: React.ComponentProps<C>
+): React.ComponentProps<C> {
+  const overridesContext = React.useContext(OverridesContext)
+  return getOverrideProps(overridesContext, component, props)
 }
 
 export type OverridesProps = {

--- a/packages/react/src/Variants.tsx
+++ b/packages/react/src/Variants.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react'
 
-const VariantsContext = React.createContext([])
+export const VariantsContext = React.createContext([])
 
-export function useVariantProps<Props>({
-  variants,
-  ...props
-}: { variants?: object } & Props): Omit<Props, 'variants'> {
-  const contextVariants = React.useContext(VariantsContext)
+export function getVariantProps(variantsContext, { variants, ...props }: any) {
   let mergedProps = { ...props }
   if (variants) {
-    Object.entries(contextVariants).forEach(([variant, active]) => {
+    Object.entries(variantsContext).forEach(([variant, active]) => {
       const variantProps = variants[variant]
       // we intentionally call each function no matter what since variants can
       // contain hooks and need to run in the same order on every render
@@ -27,7 +23,7 @@ export function useVariantProps<Props>({
   }
   // check and convert boolean props that have a variant value
   // <Text visible="checkout-success">Success!</Text>
-  Object.entries(contextVariants).forEach(([variant, active]) => {
+  Object.entries(variantsContext).forEach(([variant, active]) => {
     Object.entries(props).forEach(([prop, value]) => {
       if (value === variant) {
         mergedProps[prop] = active
@@ -35,6 +31,11 @@ export function useVariantProps<Props>({
     })
   })
   return mergedProps
+}
+
+export function useVariantProps<Props>(props: Props) {
+  const variantsContext = React.useContext(VariantsContext)
+  return getVariantProps(variantsContext, props) as Omit<Props, 'variants'>
 }
 
 export type VariantsProps = {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,5 +11,6 @@ export * from './Tokens'
 export * from './Variants'
 
 export * from './jsx'
+export * from './use-child-props'
 export * from './use-geometry'
 export * from './types'

--- a/packages/react/src/use-child-props.ts
+++ b/packages/react/src/use-child-props.ts
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+import { OverridesContext, getOverrideProps } from './Overrides'
+import { VariantsContext, getVariantProps } from './Variants'
+
+export function useChildProps() {
+  const overridesContext = React.useContext(OverridesContext)
+  const variantsContext = React.useContext(VariantsContext)
+  return (child) => {
+    const { __originalType, ...props } = child.props
+    const overrideProps = getOverrideProps(
+      overridesContext,
+      __originalType,
+      props
+    )
+    const variantProps = getVariantProps(variantsContext, overrideProps)
+    return variantProps
+  }
+}


### PR DESCRIPTION
Refactors `Overrides` and `Variants` to export helper functions that can be used in the new `useChildProps` hook. This hook resolves values based on parent `Overrides` and `Variants` when reading child props.

Using a custom  `HStack` component as an example we can utilize `useChildProps` when looping over children:
```jsx
import { useChildProps } from '@jsxui/react'
import { Children, cloneElement } from 'react'

function HStack({ children }) {
  const getChildProps = useChildProps()
  const columns = Children.toArray(children).map((child) => {
    const childProps = getChildProps(child)
    return childProps.width
  })
  return (
    <div
      style={{
        display: 'grid',
        gridAutoFlow: 'column',
        gridTemplateColumns: columns.join(' '),
      }}
    >
      {children}
    </div>
  )
}
```

Now when `HStack` clones children it will properly resolve the value to `{ width: '1fr', color: 'white' }`.

```jsx
/** @jsx jsx */
import { jsx, Text } from '@jsxui/react'
import { HStack } from './HStack'

function App() {
  return (
    <Overrides value={[<Text width="1fr" color="white" />]}}>
      <HStack background="black">
        <Text>Stacks</Text>
        <Text>Rule</Text>
        <Text>Everything</Text>
        <Text>Around</Text>
        <Text>Me</Text>
      </HStack>
    </Overrides>
  )
}
```