### PR TITLE
feat(Tokens): add support for alias tokens

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "capsize": "^1.1.0",
+    "dlv": "^1.1.3",
     "lodash.debounce": "^4.0.8",
     "react-polymorphic-box": "^3.0.2",
     "zustand": "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,6 +4915,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"


### PR DESCRIPTION
Adds support for using tokens within tokens:

```jsx
<Tokens colors={{ brand: 'blue', separatorFocus: 'brand' }}>
 ...
</Tokens>
```

Or nested tokens:

```jsx
<Tokens colors={{ brand: 'tomato' }}>
  <Tokens colors={{ buttonPrimary: 'brand' }}>
   ...
  </Tokens>
</Tokens>
```