### PR TITLE
feat(Variants): component variants

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "capsize": "^1.1.0",
     "lodash.debounce": "^4.0.8",
+    "merge-props": "^5.0.3",
     "react-polymorphic-box": "^3.0.2",
     "zustand": "^3.2.0"
   }

--- a/packages/react/src/Variants.tsx
+++ b/packages/react/src/Variants.tsx
@@ -36,7 +36,10 @@ export function getVariantProps(variantsContext, { variants, ...props }: any) {
 export function useVariantProps<Props>(props: Props, localVariants: object) {
   const contextVariants = React.useContext(VariantsContext)
   return getVariantProps(
-    { ...contextVariants, ...localVariants },
+    {
+      ...localVariants,
+      ...contextVariants,
+    },
     props
   ) as Omit<Props, 'variants'>
 }

--- a/packages/react/src/Variants.tsx
+++ b/packages/react/src/Variants.tsx
@@ -33,9 +33,12 @@ export function getVariantProps(variantsContext, { variants, ...props }: any) {
   return mergedProps
 }
 
-export function useVariantProps<Props>(props: Props) {
-  const variantsContext = React.useContext(VariantsContext)
-  return getVariantProps(variantsContext, props) as Omit<Props, 'variants'>
+export function useVariantProps<Props>(props: Props, localVariants: object) {
+  const contextVariants = React.useContext(VariantsContext)
+  return getVariantProps(
+    { ...contextVariants, ...localVariants },
+    props
+  ) as Omit<Props, 'variants'>
 }
 
 export type VariantsProps = {

--- a/packages/react/src/jsx.tsx
+++ b/packages/react/src/jsx.tsx
@@ -1,26 +1,27 @@
 import * as React from 'react'
+import mergeProps from 'merge-props'
 
 import { useOverrideProps } from './Overrides'
 import { useVariantProps } from './Variants'
 
-type CreateElementProps = {
-  __originalType: React.ElementType
-  __jsxuiSource: {
-    fileName: string
-    lineNumber: number
-    columnNumber: number
+export const CreateElement = React.forwardRef((props: any, ref) => {
+  const variants = props.__originalType.variants
+  const localVariants = {}
+  if (variants) {
+    for (let key in variants) {
+      const variantHook = variants[key]
+      const [active, hookProps] = variantHook()
+      localVariants[key] = active
+      props = mergeProps(hookProps, props)
+    }
   }
-}
-
-export const CreateElement = React.forwardRef(
-  (props: CreateElementProps, ref) => {
-    const overrideProps = useOverrideProps(props.__originalType, props)
-    const { __originalType, __jsxuiSource, ...variantProps } = useVariantProps(
-      overrideProps
-    )
-    return React.createElement(props.__originalType, { ref, ...variantProps })
-  }
-)
+  const overrideProps = useOverrideProps(props.__originalType, props)
+  const { __originalType, __jsxuiSource, ...variantProps } = useVariantProps(
+    overrideProps,
+    localVariants
+  )
+  return React.createElement(props.__originalType, { ref, ...variantProps })
+})
 
 CreateElement.displayName = 'JSXUICreateElement'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,6 +9232,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-props@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/merge-props/-/merge-props-5.0.3.tgz#1c89c40f81b932ad66ea069b1b5f38deb0cd5247"
+  integrity sha512-TuntFuNELf4ZEMZEDM32hCpACQStDfeEMlN5R499gRQB4XUIaGuLrQhm+nRMDtPwCWEZ2a2KTGnTxfjK8B1zww==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"


### PR DESCRIPTION
Adds a second argument to `useVariantProps` to provide your own local variants:

```jsx
function Button(props) {
  const [focus, setFocus] = React.useState(false)
  const variantProps = useVariantProps(props, { focus })
  return (
    <button
      onFocus={() => setFocus(true)}
      onBlur={() => setFocus(false)}
      {...variantProps}
    />
  )
}
```

As well as the ability to  define component variants that are read in the pragma:

```jsx
function Button(props) {
  const [focus, setFocus] = React.useState(false)
  const variantProps = useVariantProps(props, { focus })
  return (
    <button
      onFocus={() => setFocus(true)}
      onBlur={() => setFocus(false)}
      {...variantProps}
    />
  )
}
Button.variants = {
  focus: () => {
    const [focus, setFocus] = React.useState(false)
    return [
      focus,
      {
        onFocus: () => setFocus(true),
        onBlur: () => setFocus(false)
      }
    ]
  }
}
```

This makes it easy for consumers to customize variants using `Overrides`:

```jsx
function App() {
  return (
    <Overrides
      value={[
        <TextField
          strokeWeight={1}
          strokeColor="black"
          variants={{
            hover: {
              strokeColor: 'separatorHover',
            },
            focus: {
              strokeWeight: 2,
              strokeColor: 'separatorFocus',
            },
          }}
        />,
      ]}
    >
      ...
    </Overrides>
  )
}
```