### PR TITLE
chore: migrate to react-polymorphic-types

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
     "dlv": "^1.1.3",
     "lodash.debounce": "^4.0.8",
     "merge-props": "^5.0.3",
-    "react-polymorphic-box": "^3.0.2",
+    "react-polymorphic-types": "^1.0.3",
     "zustand": "^3.2.0"
   }
 }

--- a/packages/react/src/Text.tsx
+++ b/packages/react/src/Text.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react'
+import {
+  PolymorphicForwardRefExoticComponent,
+  PolymorphicPropsWithoutRef,
+  PolymorphicPropsWithRef,
+} from 'react-polymorphic-types'
 import capsize from 'capsize'
 
 import { StackContext } from './Contexts'
 import { useTokens } from './Tokens'
-import { DefaultProps } from './index'
+import { SharedProps } from './index'
 import { useLayoutStyles } from './use-layout-styles'
 import { parseValue } from './utils'
+
+const defaultElement = 'span'
 
 export type TextOwnProps = {
   alignment?: 'left' | 'center' | 'right'
@@ -27,23 +34,19 @@ export type TextOwnProps = {
   opacity?: number | string
   style?: React.CSSProperties
   children?: React.ReactNode
-}
+} & SharedProps
 
-export type TextProps<E extends React.ElementType> = DefaultProps<
-  E,
-  TextOwnProps
->
+export type TextProps<
+  T extends React.ElementType = typeof defaultElement
+> = PolymorphicPropsWithRef<TextOwnProps, T>
 
-const defaultElement = 'span'
-
-export const Text = React.forwardRef(
-  <E extends React.ElementType = typeof defaultElement>(
-    props: TextProps<E>,
-    ref
-  ) => {
-    const isMainAxisHorizontal = React.useContext(StackContext)
-    const {
-      as: Component = 'span',
+export const Text: PolymorphicForwardRefExoticComponent<
+  TextOwnProps,
+  typeof defaultElement
+> = React.forwardRef(
+  <T extends React.ElementType = typeof defaultElement>(
+    {
+      as,
       alignment,
       column,
       row,
@@ -67,7 +70,11 @@ export const Text = React.forwardRef(
       style = {},
       children,
       ...restProps
-    } = props
+    }: PolymorphicPropsWithoutRef<TextOwnProps, T>,
+    ref: React.ForwardedRef<React.ElementRef<T>>
+  ) => {
+    const Element: React.ElementType = as || defaultElement
+    const isMainAxisHorizontal = React.useContext(StackContext)
     const layoutStyles = useLayoutStyles(isMainAxisHorizontal ? width : height)
     const {
       colors,
@@ -98,7 +105,7 @@ export const Text = React.forwardRef(
     }
 
     return (
-      <Component
+      <Element
         ref={ref}
         style={{
           display: 'inline-block',
@@ -138,12 +145,9 @@ export const Text = React.forwardRef(
             marginBottom: fontStyles['::after']?.marginBottom,
           }}
         />
-      </Component>
+      </Element>
     )
   }
-) as <E extends React.ElementType = typeof defaultElement>(
-  props: TextProps<E>
-) => React.ReactElement
+)
 
-// @ts-ignore
 Text.displayName = 'Text'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,16 +1,3 @@
-import * as React from 'react'
-import { PolymorphicComponentProps } from 'react-polymorphic-box'
-
-export type DefaultProps<
-  C extends React.ElementType,
-  Props = {}
-> = PolymorphicComponentProps<C, Props> & {
-  column?: string
-  row?: string
-  variants?: any
-  visible?: boolean | string
-}
-
 export type SharedProps = {
   column?: string
   row?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -11311,10 +11311,10 @@ react-maps-google@^0.4.10:
     prop-types "^15.6.1"
     react-load-script "0.0.6"
 
-react-polymorphic-box@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-polymorphic-box/-/react-polymorphic-box-3.0.2.tgz#f7830deac08b0ae55226a85a2cc2bfa0af53e8f1"
-  integrity sha512-6nTfLUgYPuniGaosD2uDMmS/ZHh4xu2BtscNYZK6HMaVyDgdk4qo2grsEBreOR5CS9Lz4wS835DBKPZ53dFPXg==
+react-polymorphic-types@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-polymorphic-types/-/react-polymorphic-types-1.0.3.tgz#fa4a33e56d2e3a324e4e4a3b81447791aba35120"
+  integrity sha512-FVLrK9nEvr+gTIPf2lw/AzYOaeWRGbSdFLA+qqQIVNpCpdwqZqHkmhpTaChpZkG+Xub1fPMEuLmXTwNykVxbbQ==
 
 react-refresh@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
Migrates `Stack` and `Text` types from `react-polymorphic-box` to `react-polymorphic-types`.