### PR TITLE
feat(Variants): pass state to functions

### DIFF
--- a/packages/react/src/Variants.tsx
+++ b/packages/react/src/Variants.tsx
@@ -5,28 +5,26 @@ export const VariantsContext = React.createContext([])
 export function getVariantProps(variantsContext, { variants, ...props }: any) {
   let mergedProps = { ...props }
   if (variants) {
-    Object.entries(variantsContext).forEach(([variant, active]) => {
+    Object.entries(variantsContext).forEach(([variant, state]) => {
       const variantProps = variants[variant]
-      // we intentionally call each function no matter what since variants can
-      // contain hooks and need to run in the same order on every render
-      const nextProps =
-        typeof variantProps === 'function'
-          ? variantProps(mergedProps, active)
-          : variantProps
-      if (active) {
-        mergedProps = {
-          ...mergedProps,
-          ...nextProps,
+      if (state) {
+        if (typeof variantProps === 'function') {
+          mergedProps = variantProps(mergedProps, state)
+        } else {
+          mergedProps = {
+            ...mergedProps,
+            ...variantProps,
+          }
         }
       }
     })
   }
   // check and convert boolean props that have a variant value
   // <Text visible="checkout-success">Success!</Text>
-  Object.entries(variantsContext).forEach(([variant, active]) => {
+  Object.entries(variantsContext).forEach(([variant, state]) => {
     Object.entries(props).forEach(([prop, value]) => {
       if (value === variant) {
-        mergedProps[prop] = active
+        mergedProps[prop] = state
       }
     })
   })


### PR DESCRIPTION
This adds the ability to pass state to variants for advanced functionality. Previously we relied on passing hooks, but this breaks the rules of hooks and is now no longer supported. Props must also be forwarded now, this is so the consumer can choose how to merge props for each variant.

This example is taken from the `DevTools` component which now uses this feature:

```jsx
function Editor({ children }) {
  const [editorMode, setEditorMode] = React.useState(false)
  const [editorActiveElement, setEditorActiveElement] = React.useState(null)
  const editorVariant = (props) => ({
    ...props,
    onMouseOver: (event) => {
      event.stopPropagation()
      setEditorActiveElement(props.__jsxuiSource)
    },
    onMouseOut: () => {
      setEditorActiveElement(null)
    },
    onClick: (event) => {
      event.preventDefault()
      event.stopPropagation()
      setEditorActiveElement(props.__jsxuiSource)
    },
  })
  const editorActiveVariant = (props, state) => {
    const active = JSON.stringify(state) === JSON.stringify(props.__jsxuiSource)
    return active
      ? {
          ...props,
          style: {
            ...props.style,
            outline: `3px solid blue`,
            zIndex: 100,
          },
        }
      : props
  }
  React.useEffect(() => {
    document.addEventListener('keydown', (event) => {
      switch (event.key) {
        case 'e':
          setEditorMode((bool) => !bool)
          break
        case 'Escape':
          setEditorActiveElement(null)
          break
      }
    })
  }, [])
  React.useEffect(() => {
    if (editorMode === false) {
      setEditorActiveElement(null)
    }
  }, [editorMode])
  return (
    <Variants value={{ editorMode, editorActiveElement }}>
      <Overrides
        value={[
            <Stack
              variants={{
                editorMode: editorVariant,
                editorActiveElement: editorActiveVariant,
              }}
            />
        ]}
      >
        {children}
      </Overrides>
    </Variants>
  )
}
```